### PR TITLE
- Fixed: Using ACCOUNT object inside a trigger checked if the SRC had…

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -1,5 +1,5 @@
 ﻿
----- 0.56d (eXperimental branch forked from 0.56d) --------------------------------------------------------------
+---- 0.56d (former eXperimental branch, now simply Sphere-X, forked from 0.56d) --------------------------------------------------------------
 ---- 11/04/2016
 
 10-04-2016, Coruja
@@ -2170,3 +2170,6 @@ Must have event, even if it's empty, since it's applied by the source to generat
 
 07-04-2020, xwerswoodx
 - Fixed: The issue on Resurrection, which causes the server freezes. (Issue #398)
+
+09-04-2020, Nolok
+- Fixed: Using ACCOUNT object inside a trigger checked if the SRC had high enough privilege (PLEVEL) to access/modify ACCOUNT's properties, instead of acting with the highest PLEVEL (Issue #391).

--- a/src/common/CScriptObj.cpp
+++ b/src/common/CScriptObj.cpp
@@ -1136,6 +1136,23 @@ bool CScriptObj::r_Verb( CScript & s, CTextConsole * pSrc ) // Execute command f
 			CScript script(ptcKey, s.GetArgStr());
 			script.m_iResourceFileIndex = s.m_iResourceFileIndex;	// Index in g_Cfg.m_ResourceFiles of the CResourceScript (script file) where the CScript originated
 			script.m_iLineNum = s.m_iLineNum;						// Line in the script file where Key/Arg were read
+
+			if ( dynamic_cast<CAccount*>(pRef) != nullptr)
+			{
+				// Dirty fix:
+				// If the REF is an ACCOUNT, it does special checks with the SRC to compare the PrivLevel to allow read/write its values.
+				//	If i'm running in a trigger, so in a script, get the max privileges and change the SRC.
+				CObjBase* pThisObj = dynamic_cast<CObjBase*>(this);
+				if (pThisObj)
+				{
+					if (pThisObj->IsRunningTrigger())
+					{
+						pSrc = &g_Serv;
+						ASSERT(pSrc);
+					}
+				}	
+			}
+
 			return pRef->r_Verb( script, pSrc );
 		}
 		// else just fall through. as they seem to be setting the pointer !?

--- a/src/common/CServerMap.cpp
+++ b/src/common/CServerMap.cpp
@@ -523,7 +523,7 @@ void CServerMapBlock::Load( int bx, int by )
 }
 
 CServerMapBlock::CServerMapBlock(int bx, int by, int map) :
-		CPointSort((short)(bx)* UO_BLOCK_SIZE, (short)(by) * UO_BLOCK_SIZE, (uchar)map)
+		CPointSort((short)(bx)* UO_BLOCK_SIZE, (short)(by) * UO_BLOCK_SIZE, 0, (uchar)map)
 {
 	++sm_iCount;
 	Load( bx, by );

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -35,9 +35,11 @@
 
 #if __cplusplus >= 201703L  // is C++17 enabled?
     #define FALLTHROUGH [[fallthrough]]
+	#define NODISCARD	[[nodiscard]]
 #else
     #define FALLTHROUGH // fall through
     /* yep, the comment appears to silence the warning with GCC, dunno for clang */
+	#define NODISCARD
 #endif
 
 

--- a/src/common/sphere_library/sstring.h
+++ b/src/common/sphere_library/sstring.h
@@ -65,10 +65,10 @@ uint   Str_ToUI (lpctstr ptcStr, int base = 10) noexcept;
 llong  Str_ToLL (lpctstr ptcStr, int base = 10) noexcept;
 ullong Str_ToULL(lpctstr ptcStr, int base = 10) noexcept;
 
-tchar* Str_FromI   (int val,    tchar* buf, int base = 10) noexcept;
-tchar* Str_FromUI  (uint val,   tchar* buf, int base = 10) noexcept;
-tchar* Str_FromLL  (llong val,  tchar* buf, int base = 10) noexcept;
-tchar* Str_FromULL (ullong val, tchar* buf, int base = 10) noexcept;
+tchar* NODISCARD Str_FromI   (int val,    tchar* buf, int base = 10) noexcept;
+tchar* NODISCARD Str_FromUI  (uint val,   tchar* buf, int base = 10) noexcept;
+tchar* NODISCARD Str_FromLL  (llong val,  tchar* buf, int base = 10) noexcept;
+tchar* NODISCARD Str_FromULL (ullong val, tchar* buf, int base = 10) noexcept;
 
 
 size_t FindStrWord( lpctstr pTextSearch, lpctstr pszKeyWord );

--- a/src/game/CContainer.cpp
+++ b/src/game/CContainer.cpp
@@ -316,13 +316,19 @@ int CContainer::ContentConsume( const CResourceID& rid, int amount, dword dwArg 
 		{
 			if ( rid == CResourceID(RES_TYPEDEF, IT_GOLD) )
 			{
-				if ( pCont->IsType(IT_CONTAINER_LOCKED) )
+				if (pCont->IsType(IT_CONTAINER_LOCKED))
+				{
+					++i;
 					continue;
+				}
 			}
 			else
 			{
-				if ( !pCont->IsSearchable() )
+				if (!pCont->IsSearchable())
+				{
+					++i;
 					continue;
+				}
 			}
 			amount = pCont->ContentConsume(rid, amount, dwArg);
 			if ( amount <= 0 )

--- a/src/game/CObjBase.cpp
+++ b/src/game/CObjBase.cpp
@@ -3228,6 +3228,11 @@ TRIGRET_TYPE CObjBase::Spell_OnTrigger( SPELL_TYPE spell, SPTRIG_TYPE stage, CCh
 	return TRIGRET_RET_DEFAULT;
 }
 
+bool CObjBase::IsRunningTrigger() const
+{
+	return ((_iRunningTriggerId >= 0) || !_sRunningTrigger.empty());
+}
+
 bool CObjBase::CallPersonalTrigger(tchar * pArgs, CTextConsole * pSrc, TRIGRET_TYPE & trResult)
 {
 	ADDTOCALLSTACK("CObjBase::CallPersonalTrigger");

--- a/src/game/CObjBase.h
+++ b/src/game/CObjBase.h
@@ -35,8 +35,8 @@ protected:
 	CResourceRef m_BaseRef;     // Pointer to the resource that describes this type.
 
     std::string _sRunningTrigger;   // Name of the running trigger (can be custom!) [use std::string instead of CSString because the former is allocated on-demand]
-    short _iRunningTriggerId;     // Current trigger being run on this object. Used to prevent the same trigger being called over and over.
-    short _iCallingObjTriggerId;  // I am running a trigger called via TRIGGER (CallPersonalTrigger method). In which trigger (OF THIS SAME OBJECT) was this call executed?
+    short _iRunningTriggerId;       // Current trigger being run on this object. Used to prevent the same trigger being called over and over.
+    short _iCallingObjTriggerId;    // I am running a trigger called via TRIGGER (CallPersonalTrigger method). In which trigger (OF THIS SAME OBJECT) was this call executed?
 
 public:
     static const char *m_sClassName;
@@ -87,6 +87,8 @@ public:
 	{
 		return (GetCanFlags() & dwCan);
 	}
+
+    bool IsRunningTrigger() const;
 
 	/**
 	* @fn  inline bool CObjBase::CallPersonalTrigger(tchar * pArgs, CTextConsole * pSrc, TRIGRET_TYPE & trResult, bool bFull);
@@ -512,24 +514,6 @@ public:
      * @param   fItem   true to item.
      */
 	void SetUID( dword dwVal, bool fItem );
-
-    /**
-     * @fn  CObjBase* CObjBase::GetNext() const;
-     *
-     * @brief   Gets the next item.
-     *
-     * @return  null if it fails, else the next.
-     */
-	CObjBase* GetNext() const;
-
-    /**
-     * @fn  CObjBase* CObjBase::GetPrev() const;
-     *
-     * @brief   Gets the previous item.
-     *
-     * @return  null if it fails, else the previous.
-     */
-	CObjBase* GetPrev() const;
 
     /**
      * @fn  virtual lpctstr CObjBase::GetName() const;

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -1162,7 +1162,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 		case LAYER_SPELL_Gift_Of_Renewal:
 			if (pClient && IsSetOF(OF_Buffs))
 			{
-				Str_FromI(pSpell->m_itSpell.m_spelllevel,NumBuff[0], 10);
+				itoa(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
 				pClient->removeBuff(BI_GIFTOFRENEWAL);
 				pClient->addBuff(BI_GIFTOFRENEWAL, 1075796, 1075797, wTimerEffect, pNumBuff, 1);
 			}
@@ -1170,7 +1170,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 		case LAYER_SPELL_Attunement:
 			if (pClient && IsSetOF(OF_Buffs))
 			{
-				Str_FromI(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
+				itoa(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
 				pClient->removeBuff(BI_ATTUNEWEAPON);
 				pClient->addBuff(BI_ATTUNEWEAPON, 1075798, 1075799, wTimerEffect, pNumBuff, 1);
 			}
@@ -1178,7 +1178,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 		case LAYER_SPELL_Thunderstorm:
 			if (pClient && IsSetOF(OF_Buffs))
 			{
-				Str_FromI(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
+				itoa(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
 				pClient->removeBuff(BI_THUNDERSTORM);
 				pClient->addBuff(BI_THUNDERSTORM, 1075800, 1075801, wTimerEffect, pNumBuff, 1);
 			}
@@ -1186,7 +1186,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 		case LAYER_SPELL_Essence_Of_Wind:
 			if (pClient && IsSetOF(OF_Buffs))
 			{
-				Str_FromI(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
+				itoa(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
 				pClient->removeBuff(BI_ESSENCEOFWIND);
 				pClient->addBuff(BI_ESSENCEOFWIND, 1075802, 1075803, wTimerEffect, pNumBuff, 1);
 			}
@@ -1208,8 +1208,8 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 		case LAYER_SPELL_Arcane_Empowerment:
 			if (pClient && IsSetOF(OF_Buffs))
 			{
-				Str_FromI(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
-				Str_FromI(pSpell->m_itSpell.m_spellcharges,NumBuff[1], 10);
+				itoa(pSpell->m_itSpell.m_spelllevel, NumBuff[0], 10);
+				itoa(pSpell->m_itSpell.m_spellcharges,NumBuff[1], 10);
 				pClient->removeBuff(BI_ARCANEEMPOWERMENT);
 				pClient->addBuff(BI_ARCANEEMPOWERMENT, 1075805, 1075804, wTimerEffect, pNumBuff, 1);
 			}
@@ -1342,9 +1342,9 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				pClient->removeBuff(BI_REACTIVEARMOR);
 				if ( IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) )
 				{
-					Str_FromI(wStatEffectRef, NumBuff[0], 10);
+					itoa(wStatEffectRef, NumBuff[0], 10);
 					for ( int idx = 1; idx < 5; ++idx )
-						Str_FromI(5, NumBuff[idx], 10);
+						itoa(5, NumBuff[idx], 10);
 
 					pClient->addBuff(BI_REACTIVEARMOR, 1075812, 1075813, wTimerEffect, pNumBuff, 5);
 				}
@@ -1365,7 +1365,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				Stat_AddMod( STAT_DEX, -wStatEffectRef );
 				if (pClient && IsSetOF(OF_Buffs))
 				{
-					Str_FromI(wStatEffectRef, NumBuff[0], 10);
+					itoa(wStatEffectRef, NumBuff[0], 10);
 					pClient->removeBuff(BI_CLUMSY);
 					pClient->addBuff(BI_CLUMSY, 1075831, 1075832, wTimerEffect, pNumBuff, 1);
 				}
@@ -1396,7 +1396,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				Stat_AddMod( STAT_INT, -wStatEffectRef );
 				if (pClient && IsSetOF(OF_Buffs))
 				{
-					Str_FromI(wStatEffectRef, NumBuff[0], 10);
+					itoa(wStatEffectRef, NumBuff[0], 10);
 					pClient->removeBuff(BI_FEEBLEMIND);
 					pClient->addBuff(BI_FEEBLEMIND, 1075833, 1075834, wTimerEffect, pNumBuff, 1);
 				}
@@ -1413,7 +1413,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				Stat_AddMod( STAT_STR, -wStatEffectRef );
 				if (pClient && IsSetOF(OF_Buffs))
 				{
-					Str_FromI(wStatEffectRef, NumBuff[0], 10);
+					itoa(wStatEffectRef, NumBuff[0], 10);
 					pClient->removeBuff(BI_WEAKEN);
 					pClient->addBuff(BI_WEAKEN, 1075837, 1075838, wTimerEffect, pNumBuff, 1);
 				}
@@ -1446,11 +1446,11 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				{
 					pClient->removeBuff(BI_CURSE);
 					for ( int idx = STAT_STR; idx < STAT_BASE_QTY; ++idx )
-						Str_FromI(wStatEffectRef, NumBuff[idx], 10);
+						itoa(wStatEffectRef, NumBuff[idx], 10);
 					if ( IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) )
 					{
 						for ( int idx = 3; idx < 7; ++idx )
-							Str_FromI(10, NumBuff[idx], 10);
+							itoa(10, NumBuff[idx], 10);
 
 						pClient->addBuff(BI_CURSE, 1075835, 1075836, wTimerEffect, pNumBuff, 7);
 					}
@@ -1472,7 +1472,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 
 				if (pClient && IsSetOF(OF_Buffs))
 				{
-					Str_FromI(wStatEffectRef, NumBuff[0], 10);
+					itoa(wStatEffectRef, NumBuff[0], 10);
 					pClient->removeBuff(BI_AGILITY);
 					pClient->addBuff(BI_AGILITY, 1075841, 1075842, wTimerEffect, pNumBuff, 1);
 				}
@@ -1487,7 +1487,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				Stat_AddMod( STAT_INT, +wStatEffectRef );
 				if (pClient && IsSetOF(OF_Buffs))
 				{
-					Str_FromI(wStatEffectRef, NumBuff[0], 10);
+					itoa(wStatEffectRef, NumBuff[0], 10);
 					pClient->removeBuff(BI_CUNNING);
 					pClient->addBuff(BI_CUNNING, 1075843, 1075844, wTimerEffect, pNumBuff, 1);
 				}
@@ -1502,7 +1502,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				Stat_AddMod( STAT_STR, +wStatEffectRef );
 				if (pClient && IsSetOF(OF_Buffs))
 				{
-					Str_FromI(wStatEffectRef, NumBuff[0], 10);
+					itoa(wStatEffectRef, NumBuff[0], 10);
 					pClient->removeBuff(BI_STRENGTH);
 					pClient->addBuff(BI_STRENGTH, 1075845, 1075846, wTimerEffect, pNumBuff, 1);
 				}
@@ -1520,7 +1520,7 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				if (pClient && IsSetOF(OF_Buffs))
 				{
 					for ( int idx = STAT_STR; idx < STAT_BASE_QTY; ++idx)
-						Str_FromI(wStatEffectRef, NumBuff[idx], 10);
+						itoa(wStatEffectRef, NumBuff[idx], 10);
 
 					pClient->removeBuff(BI_BLESS);
 					pClient->addBuff(BI_BLESS, 1075847, 1075848, wTimerEffect, pNumBuff, STAT_BASE_QTY);
@@ -1556,9 +1556,9 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 				pClient->removeBuff(BI_MAGICREFLECTION);
 				if ( IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) )
 				{
-					Str_FromI(-wStatEffectRef, NumBuff[0], 10);
+					itoa(-wStatEffectRef, NumBuff[0], 10);
 					for ( int idx = 1; idx < 5; ++idx )
-						Str_FromI(10, NumBuff[idx], 10);
+						itoa(10, NumBuff[idx], 10);
 
 					pClient->addBuff(BI_MAGICREFLECTION, 1075817, 1075818, wTimerEffect, pNumBuff, 5);
 				}
@@ -1610,8 +1610,8 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 					pClient->removeBuff(BuffIcon);
 					if ( IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) )
 					{
-						Str_FromI(-uiPhysicalResist, NumBuff[0], 10);
-						Str_FromI(-uiMagicResist/10, NumBuff[1], 10);
+						itoa(-uiPhysicalResist, NumBuff[0], 10);
+						itoa(-uiMagicResist/10, NumBuff[1], 10);
 						pClient->addBuff(BuffIcon, BuffCliloc, 1075815, wTimerEffect, pNumBuff, 2);
 					}
 					else


### PR DESCRIPTION
… high enough privilege (PLEVEL) to access/modify ACCOUNT's properties, instead of acting with the highest PLEVEL (Issue #391).

Fixed: Server Freeze when call makeitem (Issue #405).
Fixed: Server crash when cast Magic Reflection (Issue #400).
Fixed: Walkchecks not working in maps != 0.