### PR TITLE
Fix for Issue #569: NPC with stone flag keeps switching between war /…

### DIFF
--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -4400,7 +4400,7 @@ bool CChar::OnTick()
     {
         const ProfileTask aiTask(PROFILE_NPC_AI);
         EXC_SET_BLOCK("NPC action");
-        if (!IsStatFlag(STATF_FREEZE) && !Can(CAN_C_STATUE))
+        if (!IsStatFlag(STATF_FREEZE|STATF_STONE) && !Can(CAN_C_STATUE))
         {
             NPC_OnTickAction();
 


### PR DESCRIPTION
… peace mode.


There was no  "stone flag" check in the OnTick() method in CCharAct.cpp this allowed the NPC to  continue is normal behaviour and eventually reaching the Fight_CanHit method in CCharFight.cpp where it always returned  the invalid swing type causing the Fight_Clear method to be called.
This "loop" would continue until the player left the NPC line of sight.