### PR TITLE
Z Correction Tests (#1128)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3381,6 +3381,19 @@ Additionally, the problem of zig-zag issue following in the South direction has 
 08-10-2023, Nolok & xwerswoodx
 - Fixed: Setting P inside the @Click trigger made it being called endlessly.
 
+13-10-2023, xwerswoodx
+- Fixed: Made some changes on Z Calculations for maps to make it more accurate. (Issue: #♀983, #617, #877)
+	Thanks for, Jhobean, Tolokio and nolok.
+- Added: Followers now saved on characters after @FollowersUpdate trigger.
+	New system can be activated from sphere.ini by adding EF_FollowerList (080) flag to experimental flags.
+	As this save system newly added, the npcs that already follows the character not saved so their CURFOLLOWER count will reset to 0.
+	You can return 1 or set ARGN1 <= 0 to block increasing of current follower, and these characters not adding to current follower list.
+	CURFOLLOWER returns the total follower.
+	CURFOLLOWER.n.UID/CURFOLLOWER.n returns the follower uid at the given index of the list. (Feature Request: #737)
+- Fixed: @Success/@SpellSucess triggers when player try to teleport unavailable spots. (Issue: #779)
+- Fixed: Non-static items distance check fails because of wrong reference. (Issue: #1112)
+- Fixed: Setting GuardsOnMurderers to 0 causes vendors to run away players and call guards. (Issue: #720)
+
 16-10-2023, Nolok
 - Fixed: Memory leaks due to the old CSPtrTypeArray and CSObjArray containers, replaced with new ones using smart pointers as wrappers. 
 - Fixed: Possible random errors caused by reading some internal data before it was initialized during server startup (CCrypto::client_keys, holding SphereCrypt data, and ThreadHolder, holding threads data).

--- a/src/common/CPointBase.cpp
+++ b/src/common/CPointBase.cpp
@@ -700,7 +700,7 @@ bool CPointBase::r_WriteVal( lpctstr ptcKey, CSString & sVal ) const
 		}
 		default:
 		{
-			const CUOMapMeter * pMeter = CWorldMap::GetMapMeter(*this);
+			std::optional<CUOMapMeter> pMeter = CWorldMap::GetMapMeterAdjusted(*this);
 			if ( pMeter )
 			{
 				switch( index )

--- a/src/game/CObjBase.cpp
+++ b/src/game/CObjBase.cpp
@@ -1717,6 +1717,17 @@ bool CObjBase::r_LoadVal( CScript & s )
         }
     }
 
+	if (!strnicmp("FOLLOWER", ptcKey, 8))
+	{
+		if (ptcKey[8] == '.')
+		{
+			ptcKey = ptcKey + 4;
+			CUID ptcArg = (CUID)s.GetArgDWVal();
+			m_followers.emplace_back(ptcArg);
+			return true;
+		}
+	}
+
 	int index = FindTableSorted( ptcKey, sm_szLoadKeys, ARRAY_COUNT( sm_szLoadKeys )-1 );
 	if ( index < 0 )
 	{
@@ -1980,6 +1991,14 @@ void CObjBase::r_Write( CScript & s )
 
 	m_TagDefs.r_WritePrefix(s, "TAG");
 	m_OEvents.r_Write(s, "EVENTS");
+
+	for (CUID uid : m_followers)
+	{
+		dword dUID = (dword)uid;
+		char* pszTag = Str_GetTemp();
+		sprintf(pszTag, "FOLLOWER.%d", dUID);
+		s.WriteKeyHex(pszTag, dUID);
+	}
 }
 
 enum OV_TYPE

--- a/src/game/CObjBase.h
+++ b/src/game/CObjBase.h
@@ -66,6 +66,7 @@ public:
     CUID 	_uidSpawn;          // SpawnItem for this item
 
     CResourceRefArray m_OEvents;
+    std::vector<CUID> m_followers;
     
 public:
     explicit CObjBase(bool fItem);

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -45,6 +45,7 @@ enum EF_TYPE
     EF_FastWalkPrevention = 0x0000010,    // Enable client fastwalk prevention (INCOMPLETE YET).
     EF_Intrinsic_Locals = 0x0000020,    // Disables the needing of 'local.', 'tag.', etc. Be aware of not creating variables with the same name of already-existing functions.
     EF_Item_Strict_Comparison = 0x0000040,    // Don't consider log/board and leather/hide as the same resource type.
+    EF_FollowerList = 0x0000080, // Save the followers to the list and enable CURFOLLOWER.n.UID, CURFOLLOWER.ADD/DEL <UID> and CURFOLLOWER.CLEAR commands.
     EF_AllowTelnetPacketFilter = 0x0000200,    // Enable packet filtering for telnet connections as well.
     EF_Script_Profiler = 0x0000400,    // Record all functions/triggers execution time statistics (it can be viewed pressing P on console).
     EF_DamageTools = 0x0002000,    // Damage tools (and fire @damage on them) while mining or lumberjacking

--- a/src/game/CWorldMap.cpp
+++ b/src/game/CWorldMap.cpp
@@ -17,7 +17,6 @@
 #include "CWorldCache.h"
 #include "CWorldMap.h"
 
-
 //************************
 // Natural resources.
 
@@ -282,7 +281,26 @@ const CUOMapMeter* CWorldMap::GetMapMeter(const CPointMap& pt) // static
 	const CServerMapBlock* pMapBlock = GetMapBlock(pt);
 	if (!pMapBlock)
 		return nullptr;
+
 	return pMapBlock->GetTerrain(UO_BLOCK_OFFSET(pt.m_x), UO_BLOCK_OFFSET(pt.m_y));
+}
+
+std::optional<CUOMapMeter> CWorldMap::GetMapMeterAdjusted(const CPointMap& pt)
+{
+	const CUOMapMeter* pMeter = GetMapMeter(pt);
+	if (!pMeter)
+		return std::nullopt;
+	CUOMapMeter pMapTop(*pMeter);
+	const CUOMapMeter pMapLeft(CheckMapTerrain(pMapTop, pt.m_x, pt.m_y + 1, pt.m_map));
+	const CUOMapMeter pMapBottom(CheckMapTerrain(pMapTop, pt.m_x + 1, pt.m_y + 1, pt.m_map));
+	const CUOMapMeter pMapRight(CheckMapTerrain(pMapTop, pt.m_x + 1, pt.m_y, pt.m_map));
+
+	const short iAverage = GetAreaAverage(pMapTop.m_z, pMapLeft.m_z, pMapBottom.m_z, pMapRight.m_z);
+	if ((char)abs((short)pMapTop.m_z - (short)pMapBottom.m_z) > (char)abs((short)pMapLeft.m_z - (short)pMapRight.m_z))
+		pMapTop.m_z = GetFloorAvarage(pMapLeft.m_z, pMapRight.m_z, iAverage);
+	else
+		pMapTop.m_z = GetFloorAvarage(pMapTop.m_z, pMapBottom.m_z, iAverage);
+	return std::make_optional<CUOMapMeter>(pMapTop);
 }
 
 bool CWorldMap::IsTypeNear_Top( const CPointMap & pt, IT_TYPE iType, int iDistance ) // static
@@ -1201,7 +1219,7 @@ void CWorldMap::GetFixPoint( const CPointMap & pt, CServerMapBlockState & block)
 	}
 }
 
-void CWorldMap::GetHeightPoint( const CPointMap & pt, CServerMapBlockState & block, bool fHouseCheck ) // static
+void CWorldMap::GetHeightPoint(const CPointMap & pt, CServerMapBlockState & block, bool fHouseCheck) // static
 {
 	ADDTOCALLSTACK_INTENSIVE("CWorldMap::GetHeightPoint");
     const CItemBase * pItemDef = nullptr;
@@ -1427,22 +1445,22 @@ void CWorldMap::GetHeightPoint( const CPointMap & pt, CServerMapBlockState & blo
 
 	dwBlockThis = 0;
 	// Terrain height is screwed. Since it is related to all the terrain around it.
-	const CUOMapMeter * pMeter = pMapBlock->GetTerrain( UO_BLOCK_OFFSET(pt.m_x), UO_BLOCK_OFFSET(pt.m_y));
-	if ( ! pMeter )
+	std::optional<CUOMapMeter> pMapTop = GetMapMeterAdjusted(pt); //Get pMapTop Z Adjusted.
+	//const CUOMapMeter* pMapTop = pMapBlock->GetTerrain(UO_BLOCK_OFFSET(pt.m_x), UO_BLOCK_OFFSET(pt.m_y)); 
+	if (!pMapTop)
 		return;
-
-    //DEBUG_ERR(("pMeter->m_wTerrainIndex 0%x dwBlockThis (0%x)\n",pMeter->m_wTerrainIndex,dwBlockThis));
-    if (pMeter->m_wTerrainIndex == TERRAIN_HOLE)
+	//DEBUG_ERR(("pMeter->m_wTerrainIndex 0%x dwBlockThis (0%x)\n",pMeter->m_wTerrainIndex,dwBlockThis));
+    if (pMapTop->m_wTerrainIndex == TERRAIN_HOLE)
     {
         dwBlockThis = 0;
     }
-    else if (CUOMapMeter::IsTerrainNull(pMeter->m_wTerrainIndex))	// inter dungeon type.
+    else if (CUOMapMeter::IsTerrainNull(pMapTop->m_wTerrainIndex))	// inter dungeon type.
     {
         dwBlockThis = CAN_I_BLOCK;
     }
     else
     {
-        const CUOTerrainInfo land(pMeter->m_wTerrainIndex);
+        const CUOTerrainInfo land(pMapTop->m_wTerrainIndex);
         //DEBUG_ERR(("Terrain flags - land.m_flags 0%x dwBlockThis (0%x)\n",land.m_flags,dwBlockThis));
         if (land.m_flags & UFLAG1_WATER)
             dwBlockThis |= CAN_I_WATER;
@@ -1455,7 +1473,7 @@ void CWorldMap::GetHeightPoint( const CPointMap & pt, CServerMapBlockState & blo
     }
     //DEBUG_ERR(("TERRAIN dwBlockThis (0%x)\n",dwBlockThis));
 
-    block.CheckTile_Terrain(dwBlockThis, pMeter->m_z, pMeter->m_wTerrainIndex);
+    block.CheckTile_Terrain(dwBlockThis, pMapTop->m_z, pMapTop->m_wTerrainIndex);
 
 	if ( block.m_Bottom.m_z == UO_SIZE_MIN_Z )
 	{
@@ -1469,12 +1487,51 @@ void CWorldMap::GetHeightPoint( const CPointMap & pt, CServerMapBlockState & blo
 	}
 }
 
-char CWorldMap::GetHeightPoint( const CPointMap & pt, dword & dwBlockFlags, bool fHouseCheck ) // static
+const char CWorldMap::GetFloorAvarage(char pPoint1, char pPoint2, short iAverage)
+{
+	//We can't use char here, because higher points like hills has 64+ heights and adding 64+65 each other exceed char limit and causes returns minus values.
+	const short pTotal = pPoint1 + pPoint2, pHalf = pTotal / 2, pEven = pTotal % 2, pAverage = iAverage - pHalf;
+	return static_cast<char>(pHalf + (pEven != 0 && pAverage > 5));
+}
+
+const short CWorldMap::GetAreaAverage(char pTop, char pLeft, char pBottom, char pRight)
+{
+	const short iHighest1 = maximum(pTop, pBottom);
+	const short iLowest1 = minimum(pTop, pBottom);
+
+	const short iHighest2 = maximum(pLeft, pRight);
+	const short iLowest2 = minimum(pLeft, pRight);
+	return maximum(iHighest1, iHighest2) - minimum(iLowest1, iLowest2);
+}
+
+const CUOMapMeter CWorldMap::CheckMapTerrain(CUOMapMeter pDefault, short x, short y, uchar map)
+{
+	CPointMap pt = { x, y, 0, map };
+	const CServerMapBlock* pMapBlock = GetMapBlock(pt);
+	if (!pMapBlock)
+		return pDefault;
+
+	const CUOMapMeter* pMeter = pMapBlock->GetTerrain(UO_BLOCK_OFFSET(pt.m_x), UO_BLOCK_OFFSET(pt.m_y));
+	if (!pMeter)
+		return pDefault;
+
+	if (CUOMapMeter::IsTerrainNull(pMeter->m_wTerrainIndex))
+		return pDefault;
+	else
+	{
+		const CUOTerrainInfo land(pMeter->m_wTerrainIndex);
+		if ((land.m_flags & UFLAG1_WATER))
+			return pDefault;
+	}
+	return *pMeter;
+}
+
+char CWorldMap::GetHeightPoint(const CPointMap & pt, dword & dwBlockFlags, bool fHouseCheck) // static
 {
 	ADDTOCALLSTACK_INTENSIVE("CWorldMap::GetHeightPoint");
 	const dword dwCan = dwBlockFlags;
 	CServerMapBlockState block( dwBlockFlags, pt.m_z + (PLAYER_HEIGHT / 2), pt.m_z + PLAYER_HEIGHT );
-	GetHeightPoint( pt, block, fHouseCheck );
+	GetHeightPoint(pt, block, fHouseCheck);
 
 	// Pass along my results.
 	dwBlockFlags = block.m_Bottom.m_dwBlockFlags;

--- a/src/game/CWorldMap.h
+++ b/src/game/CWorldMap.h
@@ -10,6 +10,7 @@
 #include "../common/CServerMap.h"
 #include "items/item_types.h"
 #include "CSector.h"
+#include <optional>
 
 class CObjBase;
 
@@ -34,6 +35,11 @@ public:
 
 	static const CServerMapBlock* GetMapBlock(const CPointMap& pt);
 	static const CUOMapMeter* GetMapMeter(const CPointMap& pt); // Height of MAP0.MUL at given coordinates
+
+	static std::optional<CUOMapMeter> GetMapMeterAdjusted(const CPointMap& pt);
+	static const CUOMapMeter CheckMapTerrain(CUOMapMeter pDefault, short x, short y, uchar map);
+	static const char GetFloorAvarage(char pPoint1, char pPoint2, short iAverage);
+	static const short GetAreaAverage(char pTop, char pLeft, char pBottom, char pRight);
 
 	static CItemTypeDef* GetTerrainItemTypeDef(dword dwIndex);
 	static IT_TYPE		 GetTerrainItemType(dword dwIndex);

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -748,7 +748,7 @@ bool CChar::NPC_LookAtCharHuman( CChar * pChar )
 		return NPC_LookAtCharMonster( pChar );
 	}
 
-	if (( ! pChar->Noto_IsEvil() && g_Cfg.m_fGuardsOnMurderers) && (! pChar->IsStatFlag( STATF_CRIMINAL ))) 	// not interesting.
+	if (!(pChar->Noto_IsEvil() && g_Cfg.m_fGuardsOnMurderers) && (!pChar->IsStatFlag(STATF_CRIMINAL)))
 		return false;
 
 	// Yell for guard if we see someone evil.

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -2727,6 +2727,34 @@ bool CChar::Spell_TargCheck()
 			SysMessageDefault( DEFMSG_SPELL_TARG_LOS );
 			return false;
 		}
+
+		//Check if the pos for tp is valid to make sure spellsuccess trigger not trigger unnecessarily.
+		SPELL_TYPE spell = m_atMagery.m_iSpell;
+		if (spell == SPELL_Teleport && !IsPriv(PRIV_GM))
+		{
+			if (g_Cfg.m_iMountHeight)
+			{
+				if (!IsVerticalSpace(m_Act_p, false))
+				{
+					SysMessageDefault(DEFMSG_MSG_MOUNT_CEILING);
+					return false;
+				}
+			}
+			
+			// Is it a valid teleport location that allows this ?
+			CRegion* pArea = CheckValidMove(m_Act_p, nullptr, DIR_QTY, nullptr);
+			if (!pArea)
+			{
+				SysMessageDefault(DEFMSG_SPELL_TELE_CANT);
+				return false;
+			}
+			if (pArea->IsFlag(REGION_ANTIMAGIC_TELEPORT))
+			{
+				SysMessageDefault(DEFMSG_SPELL_TELE_AM);
+				return false;
+			}
+		}
+
 		if ( ! Spell_TargCheck_Face() )
 			return false;
 	}

--- a/src/game/chars/CCharStatus.cpp
+++ b/src/game/chars/CCharStatus.cpp
@@ -1447,7 +1447,7 @@ IT_TYPE CChar::CanTouchStatic( CPointMap *pPt, ITEMID_TYPE id, const CItem *pIte
 	{
 		if ( !CanTouch(pItem) )
 			return IT_JUNK;
-		*pPt = GetTopLevelObj()->GetTopPoint();
+		*pPt = pItem->GetTopLevelObj()->GetTopPoint(); //While item is available, set the target p as the item top point, not the player.
 		return pItem->GetType();
 	}
 

--- a/src/game/clients/CClientTarg.cpp
+++ b/src/game/clients/CClientTarg.cpp
@@ -130,7 +130,7 @@ bool CClient::OnTarg_Obj_Info( CObjBase * pObj, const CPointMap & pt, ITEMID_TYP
 			len = Str_CopyLimitNull( pszTemp, "[No static tile], ", STR_TEMPLENGTH);
 		}
 
-		const CUOMapMeter * pMeter = CWorldMap::GetMapMeter( pt );
+		std::optional<CUOMapMeter> pMeter = CWorldMap::GetMapMeterAdjusted( pt );
 		if ( pMeter )
 		{
 			len += snprintf( pszTemp+len, STR_TEMPLENGTH - len, "TERRAIN=0%x   TYPE=%s",

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -281,7 +281,10 @@ void PacketObjectStatus::WriteVersionSpecific(const CClient* target, CChar* othe
 	{
 		if (other->m_pPlayer != nullptr)
 		{
-			writeByte((byte)(other->GetDefNum("CURFOLLOWER", true)));
+			if (!IsSetEF(EF_FollowerList))
+				writeByte((byte)(other->GetDefNum("CURFOLLOWER", true)));
+			else
+				writeByte((byte)(other->m_followers.size()));
 			writeByte((byte)(other->GetDefNum("MAXFOLLOWER", true)));
 		}
 		else

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -229,8 +229,17 @@ UseAuthID=1
 AutoResDisp=1
 
 // Default setting for new accounts specifying default priv level
-//PRIV_DETAIL		00040	// Show combat detail messages
-//PRIV_BLOCKED		02000	// The account is blocked.
+// PRIV_GM		00002	// Acts as a GM (dif from having GM level)
+// PRIV_GM_PAGE		00008	// Listen to GM pages or not.
+// PRIV_HEARALL		00010	// I can hear everything said by people of lower plevel
+// PRIV_ALLMOVE		00020	// I can move all things. (GM only)
+// PRIV_DETAIL		00040	// Show combat detail messages
+// PRIV_DEBUG		00080	// Show all objects as boxes and chars as humans.
+// PRIV_PRIV_NOSHOW	00200	// Show the GM title and Invul flags.
+// PRIV_TELNET_SHORT	00400	// Disable broadcasts to be accepted by client
+// PRIV_JAILED		00800	// Must be /PARDONed from jail.
+// PRIV_BLOCKED		02000	// The account is blocked.
+// PRIV_ALLSHOW		04000	// Show even the offline chars.
 //AutoPrivFlags=040
 
 // How often send my hits updates to visible clients (in seconds)
@@ -417,12 +426,13 @@ CombatSpeedEra=0
 SpeedScaleFactor=15000
 
 // Parrying behaviour
-// 01 = pre-SE parrying chance formula (not using the Bushido skill). Mutually exclusive with 02 flag.
-// 02 = SE parrying chance formula (using also the Bushido skill). Mutually exclusive with 01 flag.
-// 010 = can parry with a shield
-// 020 = can parry with a one-handed weapon without a shield
-// 040 = can parry with two handed weapons
-// 080 =  Shield Armour value will scale according to the character's skill, otherwise only a 7% of the ARMOUR value is used. Not compatible with Combat Elemental Engine Flag
+// Parrying behaviour
+// PARRYERA_PRESEFORMULA 	001 // pre - SE parrying chance formula(not using the Bushido skill).Mutually exclusive with 02 flag.
+// PARRYERA_SEFORMULA		002 // SE parrying chance formula (using also the Bushido skill). Mutually exclusive with 01 flag.
+// PARRYERA_SHIELDBLOCK 	010 // can parry with a shield
+// PARRYERA_ONEHANDBLOCK	020 // can parry with a one-handed weapon without a shield
+// PARRYERA_TWOHANDBLOCK	040 // can parry with two handed weapons
+// PARRYERA_ARSCALING		080 // Shields AR scales with Parrying skill, not compatible with Combat Elemental Engine.
 CombatParryingEra=01|010
 
 //When enabled, display, in the tooltip, the Armor of the item as a percentage of its full armor value, the percentage is based  upon the body parts the item covers.
@@ -759,49 +769,50 @@ Secure=1
 // Experimental flags
 // Flags for options that affect server behaviour and which might affect compatibility
 // See the revisions.txt file for more details on this
-// EF_NoDiagonalCheckLOS		00000001 // Disable LOS checks on diagonal directions
-// EF_DynamicBackgroundsave		00000002 // This will enable, if necessary, if a backgroundsave tick is triggered to save more than only one Sector.
-// EF_ItemStacking				00000004 // Enable item stacking feature when drop items on ground
-// EF_ItemStackDrop				00000008 // The item stack will drop when an item got removed from the stack
-// EF_FastWalkPrevention		00000010 // Use new client fastwalk (speedhack) prevention instead old WalkBuffer/WalkRegen checks. (Not work at the moment don't use)
-// EF_Intrinsic_Locals			00000020 // Disables the needing of 'local.', 'tag.', etc. Be aware of not creating variables with the same name of already-existing functions
-// EF_Item_Strict_Comparison	00000040 // Don't consider log/board and leather/hide as the same resource type
-// EF_AllowTelnetPacketFilter	00000200 // Enable packet filtering for telnet connections as well
-// EF_Script_Profiler			00000400 // Record all functions/triggers execution time statistics (it can be viewed pressing P on console)
-// EF_DamageTools				00002000 // Damage tools (and fire @damage on them) while mining or lumberjacking
-// EF_UsePingServer				00008000 // Enable the experimental Ping Server (for showing pings on the server list, uses UDP port 12000)
-// EF_FixCanSeeInClosedConts	00020000 // Change CANSEE to return 0 for items inside containers that a client hasn't opened
-// EF_WalkCheckHeightMounted	00040000 // Unlike the client does, assume an height increased by 4 in walkchecks if the char is mounted. Enabling this may prevent mounted characters to walk under places they could before.
+// EF_NoDiagonalCheckLOS		000001 // Disable LOS checks on diagonal directions
+// EF_DynamicBackgroundsave		000002 // This will enable, if necessary, if a backgroundsave tick is triggered to save more than only one Sector.
+// EF_ItemStacking			000004 // Enable item stacking feature when drop items on ground
+// EF_ItemStackDrop			000008 // The item stack will drop when an item got removed from the stack
+// EF_FastWalkPrevention		000010 // Use new client fastwalk (speedhack) prevention instead old WalkBuffer/WalkRegen checks. (Not work at the moment don't use)
+// EF_Intrinsic_Locals			000020 // Disables the needing of 'local.', 'tag.', etc. Be aware of not creating variables with the same name of already-existing functions
+// EF_Item_Strict_Comparison		000040 // Don't consider log/board and leather/hide as the same resource type
+// EF_FollowerList			000080 // Save the followers to the list and enable CURFOLLOWER.n.UID, CURFOLLOWER.ADD/DEL <UID> and CURFOLLOWER.CLEAR commands.
+// EF_AllowTelnetPacketFilter		000200 // Enable packet filtering for telnet connections as well
+// EF_Script_Profiler			000400 // Record all functions/triggers execution time statistics (it can be viewed pressing P on console)
+// EF_DamageTools			002000 // Damage tools (and fire @damage on them) while mining or lumberjacking
+// EF_UsePingServer			008000 // Enable the experimental Ping Server (for showing pings on the server list, uses UDP port 12000)
+// EF_FixCanSeeInClosedConts		020000 // Change CANSEE to return 0 for items inside containers that a client hasn't opened
+// EF_WalkCheckHeightMounted		040000 // Unlike the client does, assume an height increased by 4 in walkchecks if the char is mounted. Enabling this may prevent mounted characters to walk under places they could before.
 Experimental=0
 
 // Option flags 
 // Flags for options that affect server behaviour but not compatibility
 // See the revisions.txt file for more details on this
-// OF_NoDClickTarget				00000001 // Weapons won't open a target in the cursor after DClicking them for equip.
-// OF_NoSmoothSailing				00000002 // Deactivate Smooth Sailing for clients >= 7.0.8.13
+// OF_NoDClickTarget			00000001 // Weapons won't open a target in the cursor after DClicking them for equip.
+// OF_NoSmoothSailing			00000002 // Deactivate Smooth Sailing for clients >= 7.0.8.13
 // OF_ScaleDamageByDurability		00000004 // Weapons/armors will lose DAM/AR effect based on it's current durability
-// OF_Command_Sysmsgs				00000008 // Shows status of hearall, allshow, allmove... commands after toggling them
-// OF_PetSlots						00000010 // Enable AOS pet follower slots on chars. If enabled, all players must have MAXFOLLOWER property set (default=5)
-// OF_OSIMultiSight					00000020 // Only send items inside multis when the player enter on the multi area
-// OF_Items_AutoName				00000040 // Auto rename potions/scrolls to match its spell name
-// OF_FileCommands					00000080 // Enable the usage of FILE commands
-// OF_NoItemNaming					00000100 // Disable the DEFMSG."grandmaster_mark" in crafted items
-// OF_NoHouseMuteSpeech				00000200 // Players outside multis won't hear what is told inside
-// OF_NoContextMenuLOS				00000400 // Disable LOS check to use context menus on chars
-// OF_MapBoundarySailing			00000800 // Boats will move to the other side of the map when reach map boundary
-// OF_Flood_Protection				00001000 // Prevent the server send messages to client if its the same message as the last already sent
-// OF_Buffs							00002000 // Enable the buff/debuff bar on ML clients >= 5.0.2b
-// OF_NoPrefix						00004000 // Don't show "a" and "an" prefix on item names
-// OF_DyeType						00008000 // Allow use i_dye on all items with t_dye_vat typedef instead only on i_dye_tub itemdef
-// OF_DrinkIsFood					00010000 // Typedef t_drink will increase food level like t_food
-// OF_NoDClickTurn					00020000 // Don't turn the player when DClick something
-// OF_NoPaperdollTradeTitle			00040000 // Don't show the trade title on the paperdoll
-// OF_NoTargTurn					00080000 // Don't turn the player when targetting something
-// OF_StatAllowValOverMax			00100000 // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
+// OF_Command_Sysmsgs			00000008 // Shows status of hearall, allshow, allmove... commands after toggling them
+// OF_PetSlots				00000010 // Enable AOS pet follower slots on chars. If enabled, all players must have MAXFOLLOWER property set (default=5)
+// OF_OSIMultiSight			00000020 // Only send items inside multis when the player enter on the multi area
+// OF_Items_AutoName			00000040 // Auto rename potions/scrolls to match its spell name
+// OF_FileCommands			00000080 // Enable the usage of FILE commands
+// OF_NoItemNaming			00000100 // Disable the DEFMSG."grandmaster_mark" in crafted items
+// OF_NoHouseMuteSpeech			00000200 // Players outside multis won't hear what is told inside
+// OF_NoContextMenuLOS			00000400 // Disable LOS check to use context menus on chars
+// OF_MapBoundarySailing		00000800 // Boats will move to the other side of the map when reach map boundary
+// OF_Flood_Protection			00001000 // Prevent the server send messages to client if its the same message as the last already sent
+// OF_Buffs				00002000 // Enable the buff/debuff bar on ML clients >= 5.0.2b
+// OF_NoPrefix				00004000 // Don't show "a" and "an" prefix on item names
+// OF_DyeType				00008000 // Allow use i_dye on all items with t_dye_vat typedef instead only on i_dye_tub itemdef
+// OF_DrinkIsFood			00010000 // Typedef t_drink will increase food level like t_food
+// OF_NoDClickTurn			00020000 // Don't turn the player when DClick something
+// OF_NoPaperdollTradeTitle		00040000 // Don't show the trade title on the paperdoll
+// OF_NoTargTurn			00080000 // Don't turn the player when targetting something
+// OF_StatAllowValOverMax		00100000 // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
 // OF_GuardOutsideGuardedArea		00200000 // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
-// OF_OWNoDropCarriedItem			00400000 // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+// OF_OWNoDropCarriedItem		00400000 // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
 // OF_AllowContainerInsideContainer	00800000 // Allow containers inside other containers even if they are heavier than the container being inserted into.
-// OF_VendorStockLimit              01000000 // Limits how much of an item a vendor can buy using the value set in the TEMPLATE. Format: BUY=ID,AMOUNT
+// OF_VendorStockLimit			01000000 // Limits how much of an item a vendor can buy using the value set in the TEMPLATE. Format: BUY=ID,AMOUNT
 // OF_EnableGuildAlignNotoriety		02000000 // If enabled, guilds with the same alignment will see each other as enemy or ally.
 OptionFlags=08|080|0200
 
@@ -991,11 +1002,11 @@ TeleportSoundStaff=01f3
 //ExperienceSystem=0
 
 // Experience system settings:
-//  0001    gain experience in combat
-//  0002    gain experience in crafts
-//  0004    allow experience to go down
-//  0008    limit experience decrease by a range witheen a current level
-//  0010    auto-init EXP/LEVEL for NPCs if not set in @Create
+// EXP_MODE_RAISE_COMBAT   001 // Gain experience in combat.
+// EXP_MODE_RAISE_CRAFT    002 // Gain experience in crafts.
+// EXP_MODE_ALLOW_DOWN     004 // Allow experience to go down.
+// EXP_MODE_DOWN_NOLEVEL   008 // Limit experience decrease by a range witheen a current level.
+// EXP_MODE_AUTOSET_EXP    010 // Auto-init EXP/LEVEL for NPCs if not set in @Create.
 //ExperienceMode=0
 
 // If combat experience gain is allowed, use these percents for gaining exp in


### PR DESCRIPTION
- Added: Followers now saving on the character (Feature Request: #737)
- Fixed: @Success/@SpellSucess triggers when player try to teleport unavailable spots. (Issue: #779)
* Max Follower Fix
* Added support for old curfollower system Added EF_FollowerList (080) flag to let users choose which system they wish to use.
* Update GetMapMeter to fix SERV.MAP function
- Fixed: Non-static items distance check fails because of wrong reference. (Issue: #1112)
* Fixed Setting GuardsOnMurderers Cause Vendors call guards on blue players (Issue: #720)
* Added missing flags to sphere.ini